### PR TITLE
Add email template posts

### DIFF
--- a/includes/class-wc-gutenberg-emails-loader.php
+++ b/includes/class-wc-gutenberg-emails-loader.php
@@ -57,7 +57,14 @@ class WC_Gutenberg_Emails_Loader {
 	 * Create email template posts.
 	 */
 	public function create_templates() {
-		global $wpdb;
+		global $wpdb, $pagenow;
+
+		// Only run this on the WooCommerce Emails page.
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		if ( 'edit.php' !== $pagenow || ! isset( $_GET['post_type'] ) || 'woocommerce_email' !== $_GET['post_type'] ) {
+			return;
+		}
+		// phpcs:enable
 
 		// Get already installed templates.
 		$installed_templates = $wpdb->get_col(
@@ -67,7 +74,7 @@ class WC_Gutenberg_Emails_Loader {
 		$wc_emails = WC_Emails::instance();
 
 		foreach ( $wc_emails->emails as $key => $email ) {
-			if ( in_array( strtolower( $key ), $installed_templates ) ) {
+			if ( in_array( strtolower( $key ), $installed_templates, true ) ) {
 				continue;
 			}
 

--- a/includes/class-wc-gutenberg-emails-loader.php
+++ b/includes/class-wc-gutenberg-emails-loader.php
@@ -14,7 +14,7 @@ class WC_Gutenberg_Emails_Loader {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'init_post_type' ) );
-		add_action( 'init', array( $this, 'create_emails' ) );
+		add_action( 'admin_init', array( $this, 'create_templates' ) );
 	}
 
 	/**
@@ -54,10 +54,34 @@ class WC_Gutenberg_Emails_Loader {
 	}
 
 	/**
-	 * Create emails content
+	 * Create email template posts.
 	 */
-	public function create_emails() {
-		// @todo
+	public function create_templates() {
+		global $wpdb;
+
+		// Get already installed templates.
+		$installed_templates = $wpdb->get_col(
+			"SELECT post_name FROM {$wpdb->posts} WHERE post_type = 'woocommerce_email'"
+		);
+
+		$wc_emails = WC_Emails::instance();
+
+		foreach ( $wc_emails->emails as $key => $email ) {
+			if ( in_array( strtolower( $key ), $installed_templates ) ) {
+				continue;
+			}
+
+			wp_insert_post(
+				array(
+					'post_type'    => 'woocommerce_email',
+					'post_name'    => $key,
+					'post_title'   => $email->get_default_subject(),
+					'post_content' => '', // @todo Add blocks content for email.
+					'post_status'  => 'draft',
+					'post_excerpt' => $email->description,
+				)
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #4 

Adds the registered email templates as custom posts if they haven't already been added.

### Screenshots
<img width="560" alt="Screen Shot 2019-04-24 at 7 49 54 PM" src="https://user-images.githubusercontent.com/10561050/56657259-26175100-66ca-11e9-82ec-d23222cd32d0.png">

### Testing
1. Visit the WooCommerce Emails screen in the admin.
2. Check that posts have been created for each email type with relevant info.
3. Make sure posts are not duplicated on refresh.
4. Optionally, create a new email and register through the `woocommerce_email_classes` hook to make sure it gets added.