### PR TITLE
Add email content filtering to WC emails

### DIFF
--- a/includes/class-wc-gutenberg-emails-email.php
+++ b/includes/class-wc-gutenberg-emails-email.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Initializes WooCommerce Gutenberg Emails email filters.
+ *
+ * @package Woocommerce Gutenberg Emails
+ */
+
+/**
+ * WC_Gutenberg_Emails_Email Class.
+ */
+class WC_Gutenberg_Emails_Email {
+	/**
+	 * The single instance of the class
+	 *
+	 * @var WC_Gutenberg_Emails_Email
+	 */
+	protected static $_instance = null;
+
+	/**
+	 * WC_Email or child class.
+	 *
+	 * @var WC_Gutenberg_Emails_Email[]
+	 */
+	public $email_class = null;
+
+	/**
+	 * Main WC_Gutenberg_Emails_Email Instance.
+	 *
+	 * Ensures only one instance of WC_Gutenberg_Emails_Email is loaded or can be loaded.
+	 *
+	 * @since 2.1
+	 * @static
+	 * @return WC_Emails Main instance
+	 */
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
+			self::$_instance = new self();
+		}
+		return self::$_instance;
+	}
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_filter( 'woocommerce_mail_callback_params', array( $this, 'filter_email' ), 10, 2 );
+	}
+
+	/**
+	 * Filter email subject and content for published templates.
+	 *
+	 * @param array  $mail_args Array of mail arguments.
+	 * @param object $wc_email WC_Email or child class.
+	 * @return array
+	 */
+	public function filter_email( $mail_args, $wc_email ) {
+		$this->email_class = $wc_email;
+		$template          = $this->get_template();
+
+		if ( ! $template ) {
+			return $mail_args;
+		}
+
+		// Email subject.
+		$mail_args[1] = $template->post_title;
+		// Email content.
+		$mail_args[2] = $this->get_content();
+
+		return $mail_args;
+	}
+
+	/**
+	 * Get the post template for an email.
+	 *
+	 * @return WP_Post|bool
+	 */
+	public function get_template() {
+		$templates = get_posts(
+			array(
+				'post_type'      => 'woocommerce_email',
+				'posts_per_page' => 1,
+				'name'           => strtolower( get_class( $this->email_class ) ),
+				'post_status'    => 'publish',
+			)
+		);
+
+		if ( count( $templates ) ) {
+			return $templates[0];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Replace the email content with the saved template.
+	 *
+	 * @return string
+	 */
+	public function get_content() {
+		$email_class = get_class( $this->email_class );
+		$template    = $this->get_template();
+
+		if ( property_exists( $this->email_class, 'plain_text' ) && $this->email_class->plain_text ) {
+			// @todo Set plain text email and strip tags.
+			$email_content = '';
+		} else {
+			$wc_email      = new WC_Email();
+			$email_content = $wc_email->style_inline( $template->post_content );
+		}
+
+		return $email_content;
+	}
+}
+WC_Gutenberg_Emails_Email::instance();

--- a/includes/class-wc-gutenberg-emails-loader.php
+++ b/includes/class-wc-gutenberg-emails-loader.php
@@ -73,7 +73,7 @@ class WC_Gutenberg_Emails_Loader {
 
 		$wc_emails = WC_Emails::instance();
 
-		foreach ( $wc_emails->emails as $key => $email ) {
+		foreach ( $wc_emails->get_emails() as $key => $email ) {
 			if ( in_array( strtolower( $key ), $installed_templates, true ) ) {
 				continue;
 			}

--- a/woocommerce-gutenberg-emails.php
+++ b/woocommerce-gutenberg-emails.php
@@ -26,5 +26,6 @@ if ( ! defined( 'WC_GUTENBERG_EMAILS_ABSPATH' ) ) {
  */
 function wc_gutenberg_emails_initialize() {
 	require_once WC_GUTENBERG_EMAILS_ABSPATH . 'includes/class-wc-gutenberg-emails-loader.php';
+	require_once WC_GUTENBERG_EMAILS_ABSPATH . 'includes/class-wc-gutenberg-emails-email.php';
 }
 add_action( 'woocommerce_loaded', 'wc_gutenberg_emails_initialize' );


### PR DESCRIPTION
Fixes #6 

Replaces email content and subject from title and content of Gutenberg post.

Note that placeholders and styling are not yet covered by this PR.

### Screenshots
<img width="801" alt="Screen Shot 2019-04-25 at 3 47 11 PM" src="https://user-images.githubusercontent.com/10561050/56718607-aba20c00-6771-11e9-829b-f3df9a761950.png">
<img width="650" alt="Screen Shot 2019-04-25 at 3 46 40 PM" src="https://user-images.githubusercontent.com/10561050/56718608-aba20c00-6771-11e9-8125-7b3a3120b1fa.png">

### Testing
1.  Publish one of the Gutenberg Email templates with any content.
2. Send a WC Email (creating a customer note on an order is a quick and easy way to test).
3. Check that the email sent uses the content and title from the Gutenberg email post edited earlier.