### PR TITLE
Format emails as plain text when plain text option is set

### DIFF
--- a/includes/class-wc-gutenberg-emails-email.php
+++ b/includes/class-wc-gutenberg-emails-email.php
@@ -100,9 +100,8 @@ class WC_Gutenberg_Emails_Email {
 		$email_class = get_class( $this->email_class );
 		$template    = $this->get_template();
 
-		if ( property_exists( $this->email_class, 'plain_text' ) && $this->email_class->plain_text ) {
-			// @todo Set plain text email and strip tags.
-			$email_content = '';
+		if ( 'plain' === $this->email_class->get_email_type() ) {
+			$email_content = wordwrap( preg_replace( $this->email_class->plain_search, $this->email_class->plain_replace, wp_strip_all_tags( $template->post_content ) ), 70 );
 		} else {
 			$wc_email      = new WC_Email();
 			$email_content = $wc_email->style_inline( $template->post_content );

--- a/includes/class-wc-gutenberg-emails-email.php
+++ b/includes/class-wc-gutenberg-emails-email.php
@@ -92,6 +92,32 @@ class WC_Gutenberg_Emails_Email {
 	}
 
 	/**
+	 * Get an array of strings to find for replacement.
+	 *
+	 * @return array
+	 */
+	public function get_plain_search() {
+		$plain_search = array(
+			'/^\s+/m', // Multiple blank lines.
+		);
+
+		return array_merge( $this->email_class->plain_search, $plain_search );
+	}
+
+	/**
+	 * Get an array of items used to replace found strings.
+	 *
+	 * @return array
+	 */
+	public function get_plain_replace() {
+		$plain_replace = array(
+			"\r\n", // Multiple blank lines.
+		);
+
+		return array_merge( $this->email_class->plain_replace, $plain_replace );
+	}
+
+	/**
 	 * Replace the email content with the saved template.
 	 *
 	 * @return string
@@ -101,7 +127,7 @@ class WC_Gutenberg_Emails_Email {
 		$template    = $this->get_template();
 
 		if ( 'plain' === $this->email_class->get_email_type() ) {
-			$email_content = wordwrap( preg_replace( $this->email_class->plain_search, $this->email_class->plain_replace, wp_strip_all_tags( $template->post_content ) ), 70 );
+			$email_content = wordwrap( preg_replace( $this->get_plain_search(), $this->get_plain_replace(), wp_strip_all_tags( $template->post_content ) ), 70 );
 		} else {
 			$wc_email      = new WC_Email();
 			$email_content = $wc_email->style_inline( $template->post_content );


### PR DESCRIPTION
Fixes #8 

Strips out HTML and replaces characters when an email is set to plain text.

### Screenshots
<img width="613" alt="Screen Shot 2019-04-25 at 4 36 30 PM" src="https://user-images.githubusercontent.com/10561050/56722015-bdd37880-6778-11e9-8317-6787d144da55.png">
<img width="428" alt="Screen Shot 2019-04-25 at 4 36 25 PM" src="https://user-images.githubusercontent.com/10561050/56722016-bdd37880-6778-11e9-8733-24e2fc32b516.png">

### Testing
1.  Set an email to plain text in Email settings `wp-admin/admin.php?page=wc-settings&tab=email`.
2. Make sure you have a published template for an email.
3. Trigger an email (adding a customer note to an order is an easy one).
4. Note the email is sent in plain text with no tags and special characters replaced.