### PR TITLE
 Update placeholders before sending emails

### DIFF
--- a/includes/class-wc-gutenberg-emails-email.php
+++ b/includes/class-wc-gutenberg-emails-email.php
@@ -155,9 +155,6 @@ class WC_Gutenberg_Emails_Email {
 		if ( property_exists( $this->email_class, 'customer_note' ) ) {
 			$placeholders['{customer_note}'] = $this->email_class->customer_note;
 		}
-		if ( property_exists( $this->email_class, 'customer_note' ) ) {
-			$placeholders['{customer_note}'] = $this->email_class->customer_note;
-		}
 
 		return $placeholders;
 	}

--- a/includes/class-wc-gutenberg-emails-email.php
+++ b/includes/class-wc-gutenberg-emails-email.php
@@ -62,7 +62,7 @@ class WC_Gutenberg_Emails_Email {
 		}
 
 		// Email subject.
-		$mail_args[1] = $template->post_title;
+		$mail_args[1] = $this->replace_placeholders( $template->post_title );
 		// Email content.
 		$mail_args[2] = $this->get_content();
 
@@ -108,7 +108,72 @@ class WC_Gutenberg_Emails_Email {
 			$email_content = $wc_email->style_inline( $template->post_content );
 		}
 
-		return $email_content;
+		return $this->replace_placeholders( $email_content );
+	}
+
+	/**
+	 * Get placeholders from email class objects.
+	 *
+	 * @return array
+	 */
+	public function get_placeholders() {
+		$placeholders = array();
+
+		$placeholders['{site_title}'] = $this->email_class->get_blogname();
+		$placeholders['{blogname}']   = $this->email_class->get_blogname();
+
+		if ( is_a( $this->email_class->object, 'WC_Order' ) ) {
+			$placeholders['{order_date}']              = wc_format_datetime( $this->email_class->object->get_date_created() );
+			$placeholders['{order_number}']            = $this->email_class->object->get_order_number();
+			$placeholders['{order_billing_full_name}'] = $this->email_class->object->get_formatted_billing_full_name();
+		}
+
+		if ( is_a( $this->email_class->object, 'WP_User' ) ) {
+			$placeholders['{user_login}']        = stripslashes( $this->email_class->object->user_login );
+			$placeholders['{user_email}']        = stripslashes( $this->email_class->object->user_email );
+			$placeholders['{lost_password_url}'] = esc_url(
+				add_query_arg(
+					array(
+						'key' => $this->email_class->reset_key,
+						'id'  => $this->email_class->object->ID,
+					),
+					wc_get_endpoint_url(
+						'lost-password',
+						'',
+						wc_get_page_permalink( 'myaccount' )
+					)
+				)
+			);
+		}
+
+		if ( property_exists( $this->email_class, 'user_pass' ) ) {
+			$placeholders['{user_pass}'] = $this->email_class->user_pass;
+		}
+		if ( property_exists( $this->email_class, 'password_generated' ) ) {
+			$placeholders['{password_generated}'] = $this->email_class->password_generated;
+		}
+		if ( property_exists( $this->email_class, 'customer_note' ) ) {
+			$placeholders['{customer_note}'] = $this->email_class->customer_note;
+		}
+		if ( property_exists( $this->email_class, 'customer_note' ) ) {
+			$placeholders['{customer_note}'] = $this->email_class->customer_note;
+		}
+
+		return $placeholders;
+	}
+
+	/**
+	 * Replace placeholders with object content.
+	 *
+	 * @param string $string String to search.
+	 * @return string
+	 */
+	public function replace_placeholders( $string ) {
+		$placeholders = $this->get_placeholders();
+		$find         = array_keys( $placeholders );
+		$replace      = array_values( $placeholders );
+
+		return apply_filters( 'woocommerce_email_format_string', str_replace( $find, $replace, $string ), $this );
 	}
 }
 WC_Gutenberg_Emails_Email::instance();


### PR DESCRIPTION
Fixes #7 

Replaces placeholder strings in the emails.

{site_title}
{blogname} (backwards compatibility)
{order_date}
{order_number}
{order_billing_full_name}
{user_pass}
{user_login}
{user_email}
{password_lost_url}

### Screenshots
<img width="679" alt="Screen Shot 2019-04-25 at 7 14 55 PM" src="https://user-images.githubusercontent.com/10561050/56732523-46a9de80-6790-11e9-94fa-b88885a2ec33.png">
<img width="734" alt="Screen Shot 2019-04-25 at 7 14 37 PM" src="https://user-images.githubusercontent.com/10561050/56732530-4ad5fc00-6790-11e9-92e5-55f47a5838cb.png">
<img width="288" alt="Screen Shot 2019-04-25 at 7 12 57 PM" src="https://user-images.githubusercontent.com/10561050/56732531-4ad5fc00-6790-11e9-888f-602e1df0c687.png">

### Testing
1. Create some templates using the above variables.
2. Add some of the above placeholders to the variables.
3. Trigger the emails to send.
4. Check that the placeholders were replaced by real values.
5. Check that non-relevant placeholders don't get replaced (e.g., {user_pass} in an email not related to the user password).