### PR TITLE
Add custom columns to post list

### DIFF
--- a/includes/class-wc-gutenberg-emails-admin.php
+++ b/includes/class-wc-gutenberg-emails-admin.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Admin changes for WooCommerce Gutenberg Emails.
+ *
+ * @package Woocommerce Gutenberg Emails
+ */
+
+/**
+ * WC_Gutenberg_Emails_Admin Class.
+ */
+class WC_Gutenberg_Emails_Admin {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'manage_woocommerce_email_posts_columns', array( $this, 'add_post_list_columns' ) );
+		add_filter( 'manage_woocommerce_email_posts_custom_column', array( $this, 'add_custom_column_data' ), 10, 2 );
+	}
+
+	/**
+	 * Add columns to posts list.
+	 *
+	 * @param array $columns Array of columns.
+	 * @return array
+	 */
+	public function add_post_list_columns( $columns ) {
+		$columns['title'] = __( 'Subject', 'woocommerce-gutenberg-emails' );
+		$columns['email'] = __( 'Email', 'woocommerce-gutenberg-emails' );
+
+		// Move date column to end.
+		$date_column = $columns['date'];
+		unset( $columns['date'] );
+		$columns['date'] = $date_column;
+
+		return $columns;
+	}
+
+	/**
+	 * Add column data for custom columns.
+	 *
+	 * @param string $column Column name.
+	 * @param int    $post_id Post ID.
+	 */
+	public function add_custom_column_data( $column, $post_id ) {
+		if ( 'email' === $column ) {
+			$wc_emails = WC_Emails::instance();
+			$emails    = $wc_emails->get_emails();
+			$template  = get_post( $post_id );
+
+			foreach ( $emails as $key => $email ) {
+				if ( strtolower( $key ) === $template->post_name ) {
+					echo esc_html( $emails[ $key ]->title );
+					break;
+				}
+			}
+		}
+	}
+}
+
+new WC_Gutenberg_Emails_Admin();

--- a/includes/class-wc-gutenberg-emails-admin.php
+++ b/includes/class-wc-gutenberg-emails-admin.php
@@ -15,6 +15,7 @@ class WC_Gutenberg_Emails_Admin {
 	public function __construct() {
 		add_filter( 'manage_woocommerce_email_posts_columns', array( $this, 'add_post_list_columns' ) );
 		add_filter( 'manage_woocommerce_email_posts_custom_column', array( $this, 'add_custom_column_data' ), 10, 2 );
+		add_filter( 'enter_title_here', array( $this, 'update_title_to_subject' ), 10, 2 );
 	}
 
 	/**
@@ -54,6 +55,21 @@ class WC_Gutenberg_Emails_Admin {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Update the "Add title" text to "Add email subject"
+	 *
+	 * @param string $text Text to display.
+	 * @param object $post WP_Post object.
+	 * @return string
+	 */
+	public function update_title_to_subject( $text, $post ) {
+		if ( 'woocommerce_email' === $post->post_type ) {
+			return __( 'Add email subject', 'woocommerce-gutenberg-emails' );
+		}
+
+		return $text;
 	}
 }
 

--- a/woocommerce-gutenberg-emails.php
+++ b/woocommerce-gutenberg-emails.php
@@ -30,6 +30,7 @@ if ( ! defined( 'WC_GUTENBERG_EMAILS_PLUGIN_FILE' ) ) {
  */
 function wc_gutenberg_emails_initialize() {
 	require_once WC_GUTENBERG_EMAILS_ABSPATH . 'includes/class-wc-gutenberg-emails-loader.php';
+	require_once WC_GUTENBERG_EMAILS_ABSPATH . 'includes/class-wc-gutenberg-emails-admin.php';
 	require_once WC_GUTENBERG_EMAILS_ABSPATH . 'includes/class-wc-gutenberg-emails-email.php';
 }
 add_action( 'woocommerce_loaded', 'wc_gutenberg_emails_initialize' );


### PR DESCRIPTION
Fixes #19 

* Adds the subject and original email name to the post list.
* Changes the "Enter title" text to "Enter email subject" in the Gutenberg editor.

### Screenshots
<img width="1126" alt="Screen Shot 2019-04-26 at 8 58 07 AM" src="https://user-images.githubusercontent.com/10561050/56777019-c6bc5c80-6801-11e9-94dd-714e02c30be7.png">
<img width="697" alt="Screen Shot 2019-04-26 at 8 57 58 AM" src="https://user-images.githubusercontent.com/10561050/56777020-c6bc5c80-6801-11e9-9d13-db524417b1fd.png">

### Testing
1.  Visit the post list at `wp-admin/edit.php?post_type=woocommerce_email`.
2. Make sure "Title" column is now "Subject" and that the "Email" name column has been added.
3. Open a post and make sure the title placeholder text reads "Enter email subject" when no text is entered.