### PR TITLE
Prevent post status and visibility switching

### DIFF
--- a/includes/class-wc-gutenberg-emails-admin.php
+++ b/includes/class-wc-gutenberg-emails-admin.php
@@ -94,7 +94,7 @@ class WC_Gutenberg_Emails_Admin {
 		if ( ! in_array( $new_status, $allowed_statuses, true ) ) {
 			$post->post_status = 'draft';
 			wp_update_post( $post );
-			wp_die( esc_html__( 'Email templates can only be set to published or pending.', 'woocommerce-gutenberg-emails' ) );
+			wp_die( esc_html__( 'Email templates can only be set to published or draft.', 'woocommerce-gutenberg-emails' ) );
 		}
 	}
 }

--- a/includes/class-wc-gutenberg-emails-admin.php
+++ b/includes/class-wc-gutenberg-emails-admin.php
@@ -16,6 +16,14 @@ class WC_Gutenberg_Emails_Admin {
 		add_filter( 'manage_woocommerce_email_posts_columns', array( $this, 'add_post_list_columns' ) );
 		add_filter( 'manage_woocommerce_email_posts_custom_column', array( $this, 'add_custom_column_data' ), 10, 2 );
 		add_filter( 'enter_title_here', array( $this, 'update_title_to_subject' ), 10, 2 );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_scripts_and_styles' ) );
+	}
+
+	/**
+	 * Enqueue scripts and styles.
+	 */
+	public function enqueue_scripts_and_styles() {
+		wp_enqueue_style( 'wc-gutenberg-emails-admin', plugins_url( 'build/admin.css', WC_GUTENBERG_EMAILS_PLUGIN_FILE ), array(), '0.1.0' );
 	}
 
 	/**

--- a/includes/class-wc-gutenberg-emails-admin.php
+++ b/includes/class-wc-gutenberg-emails-admin.php
@@ -82,19 +82,19 @@ class WC_Gutenberg_Emails_Admin {
 	}
 
 	/**
-	 * Restrict post statuses to draft and published.
+	 * Restrict post statuses to draft, pending, or published.
 	 *
 	 * @param string $new_status New status.
 	 * @param string $old_status Old status.
 	 * @param object $post WP_Post.
 	 */
 	public function restrict_post_transition( $new_status, $old_status, $post ) {
-		$allowed_statuses = array( 'published', 'draft' );
+		$allowed_statuses = array( 'published', 'pending', 'draft' );
 
 		if ( ! in_array( $new_status, $allowed_statuses, true ) ) {
 			$post->post_status = 'draft';
 			wp_update_post( $post );
-			wp_die( esc_html__( 'Email templates can only be set to published or draft.', 'woocommerce-gutenberg-emails' ) );
+			wp_die( esc_html__( 'Email templates can only be set to published, pending, or draft.', 'woocommerce-gutenberg-emails' ) );
 		}
 	}
 }

--- a/includes/class-wc-gutenberg-emails-admin.php
+++ b/includes/class-wc-gutenberg-emails-admin.php
@@ -17,6 +17,7 @@ class WC_Gutenberg_Emails_Admin {
 		add_filter( 'manage_woocommerce_email_posts_custom_column', array( $this, 'add_custom_column_data' ), 10, 2 );
 		add_filter( 'enter_title_here', array( $this, 'update_title_to_subject' ), 10, 2 );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_scripts_and_styles' ) );
+		add_action( 'transition_post_status', array( $this, 'restrict_post_transition' ), 10, 3 );
 	}
 
 	/**
@@ -78,6 +79,23 @@ class WC_Gutenberg_Emails_Admin {
 		}
 
 		return $text;
+	}
+
+	/**
+	 * Restrict post statuses to draft and published.
+	 *
+	 * @param string $new_status New status.
+	 * @param string $old_status Old status.
+	 * @param object $post WP_Post.
+	 */
+	public function restrict_post_transition( $new_status, $old_status, $post ) {
+		$allowed_statuses = array( 'published', 'draft' );
+
+		if ( ! in_array( $new_status, $allowed_statuses, true ) ) {
+			$post->post_status = 'draft';
+			wp_update_post( $post );
+			wp_die( esc_html__( 'Email templates can only be set to published or pending.', 'woocommerce-gutenberg-emails' ) );
+		}
 	}
 }
 

--- a/includes/class-wc-gutenberg-emails-admin.php
+++ b/includes/class-wc-gutenberg-emails-admin.php
@@ -23,7 +23,7 @@ class WC_Gutenberg_Emails_Admin {
 	 * Enqueue scripts and styles.
 	 */
 	public function enqueue_scripts_and_styles() {
-		wp_enqueue_style( 'wc-gutenberg-emails-admin', plugins_url( 'build/admin.css', WC_GUTENBERG_EMAILS_PLUGIN_FILE ), array(), '0.1.0' );
+		wp_enqueue_style( 'wc-gutenberg-emails-admin', plugins_url( 'build/admin.css', WC_GUTENBERG_EMAILS_PLUGIN_FILE ), array(), WC_GUTENBERG_EMAILS_VERSION );
 	}
 
 	/**

--- a/includes/class-wc-gutenberg-emails-loader.php
+++ b/includes/class-wc-gutenberg-emails-loader.php
@@ -31,8 +31,8 @@ class WC_Gutenberg_Emails_Loader {
 			'wp-i18n',
 		);
 
-		wp_register_script( 'wc-gutenberg-emails-order-details', plugins_url( 'build/order-details.js', WC_GUTENBERG_EMAILS_PLUGIN_FILE ), $block_dependencies, '0.1.0' );
-		wp_register_style( 'wc-gutenberg-emails-order-details', plugins_url( 'build/order-details.css', WC_GUTENBERG_EMAILS_PLUGIN_FILE ), array(), '0.1.0' );
+		wp_register_script( 'wc-gutenberg-emails-order-details', plugins_url( 'build/order-details.js', WC_GUTENBERG_EMAILS_PLUGIN_FILE ), $block_dependencies, WC_GUTENBERG_EMAILS_VERSION );
+		wp_register_style( 'wc-gutenberg-emails-order-details', plugins_url( 'build/order-details.css', WC_GUTENBERG_EMAILS_PLUGIN_FILE ), array(), WC_GUTENBERG_EMAILS_VERSION );
 	}
 
 	/**

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './style.scss';

--- a/src/admin/style.scss
+++ b/src/admin/style.scss
@@ -1,0 +1,3 @@
+.components-panel .edit-post-post-status {
+    display: none;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
 	...defaultConfig,
 	entry: {
 		'order-details': './src/blocks/order-details/index.js',
+		admin: './src/admin/index.js',
 	},
 	module: {
 		...defaultConfig.module,

--- a/woocommerce-gutenberg-emails.php
+++ b/woocommerce-gutenberg-emails.php
@@ -15,6 +15,10 @@
  * @package WC_Gutenberg_Emails
  */
 
+if ( ! defined( 'WC_GUTENBERG_EMAILS_VERSION' ) ) {
+	define( 'WC_GUTENBERG_EMAILS_VERSION', '0.1.0' );
+}
+
 if ( ! defined( 'WC_GUTENBERG_EMAILS_ABSPATH' ) ) {
 	define( 'WC_GUTENBERG_EMAILS_ABSPATH', dirname( __FILE__ ) . '/' );
 }


### PR DESCRIPTION
Fixes #14 

* Hides the "Status & Visibility" panel in the Gutenberg editor.
* Prevents status/visibility changes to posts on the backend.

### Thoughts

* This PR still allows drafts and assumes that the default PHP templates are used unless an email template is set to `published`.  I'm okay with this or forcing templates to always be published if this plugin is active, but we should probably commit to a style before going much further.
* Would love to use a JS hook instead of hiding via CSS, but it does not look like panel is made available publicly.

```js
const { removeEditorPanel } = wp.data.dispatch('core/edit-post');
removeEditorPanel( 'post-status' );
```

### Screenshots
<img width="456" alt="Screen Shot 2019-04-26 at 12 55 30 PM" src="https://user-images.githubusercontent.com/10561050/56784355-989b4480-6822-11e9-9262-b3bd1fefb699.png">
<img width="312" alt="Screen Shot 2019-04-26 at 12 53 31 PM" src="https://user-images.githubusercontent.com/10561050/56784356-989b4480-6822-11e9-8b8b-632b7f696992.png">

### Testing
1.  Attempt to change the status or visibility on an email template to anything other than `draft` or `publish`.
2. Note the error.
3. Note that switching between `draft` and `published` is still allowed.
4. Make sure the "Status & Visibility" section is hidden in the Gutenberg editor.