### PR TITLE
Add placeholders as blocks

### DIFF
--- a/includes/class-wc-gutenberg-emails-loader.php
+++ b/includes/class-wc-gutenberg-emails-loader.php
@@ -33,6 +33,7 @@ class WC_Gutenberg_Emails_Loader {
 
 		wp_register_script( 'wc-gutenberg-emails-order-details', plugins_url( 'build/order-details.js', WC_GUTENBERG_EMAILS_PLUGIN_FILE ), $block_dependencies, '0.1.0' );
 		wp_register_style( 'wc-gutenberg-emails-order-details', plugins_url( 'build/order-details.css', WC_GUTENBERG_EMAILS_PLUGIN_FILE ), array(), '0.1.0' );
+		wp_register_script( 'wc-gutenberg-emails-placeholders', plugins_url( 'build/placeholders.js', WC_GUTENBERG_EMAILS_PLUGIN_FILE ), $block_dependencies, '0.1.0' );
 	}
 
 	/**
@@ -80,6 +81,12 @@ class WC_Gutenberg_Emails_Loader {
 			array(
 				'editor_script' => 'wc-gutenberg-emails-order-details',
 				'style'         => 'wc-gutenberg-emails-order-details',
+			)
+		);
+		register_block_type(
+			'woocommerce-gutenberg-emails/placeholders',
+			array(
+				'editor_script' => 'wc-gutenberg-emails-placeholders',
 			)
 		);
 	}

--- a/src/blocks/placeholders/index.js
+++ b/src/blocks/placeholders/index.js
@@ -49,7 +49,7 @@ const placeholders = [
 		description: __( 'Display the user email address.', 'woocommerce-gutenberg-emails' ),
 	},
 	{
-		name: 'password-generateod',
+		name: 'password-generated',
 		title: __( 'Generated Password', 'woocommerce-gutenberg-emails' ),
 		description: __( 'Display the randomly generated password for the user.', 'woocommerce-gutenberg-emails' ),
 	},

--- a/src/blocks/placeholders/index.js
+++ b/src/blocks/placeholders/index.js
@@ -1,0 +1,99 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Placeholder blocks.
+ */
+const placeholders = [
+	{
+		name: 'site-title',
+		title: __( 'Site Title', 'woocommerce-gutenberg-emails' ),
+		description: __( 'Display the site title.', 'woocommerce-gutenberg-emails' ),
+	},
+	{
+		name: 'order-date',
+		title: __( 'Order Date', 'woocommerce-gutenberg-emails' ),
+		description: __( 'Display the date the order was placed.', 'woocommerce-gutenberg-emails' ),
+	},
+	{
+		name: 'order-number',
+		title: __( 'Order Number', 'woocommerce-gutenberg-emails' ),
+		description: __( 'Display the order number.', 'woocommerce-gutenberg-emails' ),
+	},
+	{
+		name: 'order-billing-full-name',
+		title: __( 'Billing Full Name', 'woocommerce-gutenberg-emails' ),
+		description: __( 'Display the full billing name from the order.', 'woocommerce-gutenberg-emails' ),
+	},
+	{
+		name: 'user-pass',
+		title: __( 'User Password', 'woocommerce-gutenberg-emails' ),
+		description: __( 'Display the user password.', 'woocommerce-gutenberg-emails' ),
+	},
+	{
+		name: 'user-login',
+		title: __( 'User Login', 'woocommerce-gutenberg-emails' ),
+		description: __( 'Display the user login name.', 'woocommerce-gutenberg-emails' ),
+	},
+	{
+		name: 'lost-password-url',
+		title: __( 'Lost Password URL', 'woocommerce-gutenberg-emails' ),
+		description: __( 'Display the URL to the lost password page.', 'woocommerce-gutenberg-emails' ),
+	},
+	{
+		name: 'user-email',
+		title: __( 'User Email', 'woocommerce-gutenberg-emails' ),
+		description: __( 'Display the user email address.', 'woocommerce-gutenberg-emails' ),
+	},
+	{
+		name: 'password-generateod',
+		title: __( 'Generated Password', 'woocommerce-gutenberg-emails' ),
+		description: __( 'Display the randomly generated password for the user.', 'woocommerce-gutenberg-emails' ),
+	},
+	{
+		name: 'customer-note',
+		title: __( 'Customer Note', 'woocommerce-gutenberg-emails' ),
+		description: __( 'Display the added customer note.', 'woocommerce-gutenberg-emails' ),
+	},
+];
+
+/**
+ * Register each of the placeholder blocks.
+ */
+placeholders.forEach( ( placeholder ) => {
+	registerBlockType( 'woocommerce-gutenberg-emails/' + placeholder.name, {
+		title: placeholder.title,
+		category: 'woocommerce-gutenberg-emails',
+		keywords: [ __( 'WooCommerce', 'woocommerce-gutenberg-emails' ) ],
+		description: placeholder.description,
+
+		/**
+		 * Renders and manages the block.
+		 *
+		 * @return {Object} Editor component.
+		 */
+		edit() {
+			return (
+				<span className="placeholder">
+					{ '{' + placeholder.name.replace( '-', '_' ) + '}' }
+				</span>
+			);
+		},
+
+		/**
+		 * Block content is rendered in PHP, not via save function.
+		 *
+		 * @return {Object} Visible component.
+		 */
+		save() {
+			return (
+				<span className="placeholder">
+					{ '{' + placeholder.name.replace( '-', '_' ) + '}' }
+				</span>
+			);
+		},
+	} );
+} );

--- a/src/blocks/placeholders/index.js
+++ b/src/blocks/placeholders/index.js
@@ -84,7 +84,7 @@ placeholders.forEach( ( placeholder ) => {
 		},
 
 		/**
-		 * Block content is rendered in PHP, not via save function.
+		 * Save the block content in the post content.
 		 *
 		 * @return {Object} Visible component.
 		 */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ const defaultConfig = require( './node_modules/@wordpress/scripts/config/webpack
 module.exports = {
 	...defaultConfig,
 	entry: {
+		placeholders: './src/blocks/placeholders/index.js',
 		'order-details': './src/blocks/order-details/index.js',
 	},
 	module: {


### PR DESCRIPTION
Fixes #11 

Adds all the placeholders as blocks.

**Note:** these blocks are not yet inlined and I'm struggling to find documentation that covers this area.  If anyone has a working example, I'll add it to this PR. Otherwise I'll try and tackle in a follow-up PR.

### Screenshots

<img width="606" alt="Screen Shot 2019-04-26 at 4 37 31 PM" src="https://user-images.githubusercontent.com/10561050/56794963-f68b5480-6841-11e9-9c4b-2b64205012cc.png">


### Testing

1.  Edit an email template.
2. Open the blocks and make sure all placeholder blocks have been added.
3. Make sure that adding blocks works (but not yet inline).