### PR TITLE
Create Email Wrapper Block

### DIFF
--- a/includes/class-wc-gutenberg-emails-email.php
+++ b/includes/class-wc-gutenberg-emails-email.php
@@ -144,8 +144,14 @@ class WC_Gutenberg_Emails_Email {
 	public function get_placeholders() {
 		$placeholders = array();
 
-		$placeholders['{site_title}'] = $this->email_class->get_blogname();
-		$placeholders['{blogname}']   = $this->email_class->get_blogname();
+		$placeholders['{site_title}']   = $this->email_class->get_blogname();
+		$placeholders['{blogname}']     = $this->email_class->get_blogname();
+		$placeholders['{heading}']      = $this->email_class->get_default_heading();
+		$placeholders['{footer}']       = wpautop( wp_kses_post( wptexturize( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) ) ) );
+		$placeholders['{header_image}'] = '';
+		if ( $img = get_option( 'woocommerce_email_header_image' ) ) {
+			$placeholders['{header_image}'] = '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . get_bloginfo( 'name', 'display' ) . '" /></p>';
+		}
 
 		if ( is_a( $this->email_class->object, 'WC_Order' ) ) {
 			$placeholders['{order_date}']              = wc_format_datetime( $this->email_class->object->get_date_created() );

--- a/includes/class-wc-gutenberg-emails-loader.php
+++ b/includes/class-wc-gutenberg-emails-loader.php
@@ -27,11 +27,13 @@ class WC_Gutenberg_Emails_Loader {
 
 		$block_dependencies = array(
 			'wp-blocks',
+			'wp-editor',
 			'wp-element',
 			'wp-i18n',
 		);
 
 		wp_register_script( 'wc-gutenberg-emails-order-details', plugins_url( 'build/order-details.js', WC_GUTENBERG_EMAILS_PLUGIN_FILE ), $block_dependencies, '0.1.0' );
+		wp_register_script( 'wc-gutenberg-emails-email-wrapper', plugins_url( 'build/email-wrapper.js', WC_GUTENBERG_EMAILS_PLUGIN_FILE ), $block_dependencies, '0.1.0' );
 		wp_register_style( 'wc-gutenberg-emails-order-details', plugins_url( 'build/order-details.css', WC_GUTENBERG_EMAILS_PLUGIN_FILE ), array(), '0.1.0' );
 	}
 
@@ -80,6 +82,12 @@ class WC_Gutenberg_Emails_Loader {
 			array(
 				'editor_script' => 'wc-gutenberg-emails-order-details',
 				'style'         => 'wc-gutenberg-emails-order-details',
+			)
+		);
+		register_block_type(
+			'woocommerce-gutenberg-emails/email-wrapper',
+			array(
+				'editor_script' => 'wc-gutenberg-emails-email-wrapper',
 			)
 		);
 	}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@wordpress/blocks": "^6.2.4",
+    "@wordpress/editor": "^9.2.4",
     "@wordpress/element": "^2.3.0",
     "@wordpress/i18n": "^3.3.0",
     "@wordpress/scripts": "^3.1.0",

--- a/src/blocks/email-wrapper/index.js
+++ b/src/blocks/email-wrapper/index.js
@@ -1,0 +1,172 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks, RichText } from '@wordpress/editor';
+
+const renderTemplate = ( { image, header, content, footer } ) => {
+	const isRTL = () => document.documentElement.dir === 'rtl';
+	return (
+		<div id="wrapper" dir={ isRTL() ? 'rtl' : 'ltr' }>
+			<table border="0" cellPadding="0" cellSpacing="0" height="100%" width="100%">
+				<tr>
+					<td align="center" valign="top">
+						<div id="template_header_image">
+							{ image }
+						</div>
+						<table border="0" cellPadding="0" cellSpacing="0" width="600" id="template_container">
+							<tr>
+								<td align="center" valign="top">
+									<table border="0" cellPadding="0" cellSpacing="0" width="600" id="template_header">
+										<tr>
+											<td id="header_wrapper">
+												{ header }
+											</td>
+										</tr>
+									</table>
+								</td>
+							</tr>
+							<tr>
+								<td align="center" valign="top">
+									<table border="0" cellPadding="0" cellSpacing="0" width="600" id="template_body">
+										<tr>
+											<td valign="top" id="body_content">
+												<table border="0" cellPadding="20" cellSpacing="0" width="100%">
+													<tr>
+														<td valign="top">
+															<div id="body_content_inner">
+																{ content }
+															</div>
+														</td>
+													</tr>
+												</table>
+											</td>
+										</tr>
+									</table>
+								</td>
+							</tr>
+							<tr>
+								<td align="center" valign="top">
+									<table border="0" cellPadding="10" cellSpacing="0" width="600" id="template_footer">
+										<tr>
+											<td valign="top">
+												<table border="0" cellPadding="10" cellSpacing="0" width="100%">
+													<tr>
+														<td colSpan="2" valign="middle" id="credit">
+															{ footer }
+														</td>
+													</tr>
+												</table>
+											</td>
+										</tr>
+									</table>
+								</td>
+							</tr>
+						</table>
+					</td>
+				</tr>
+			</table>
+		</div>
+	);
+};
+
+/**
+ * Register and run the "Order Details" block.
+ */
+registerBlockType( 'woocommerce-gutenberg-emails/email-wrapper', {
+	title: __( 'Email Wrapper', 'woocommerce-gutenberg-emails' ),
+	category: 'woocommerce-gutenberg-emails',
+	keywords: [ __( 'WooCommerce', 'woocommerce-gutenberg-emails' ) ],
+	description: __(
+		'Adds the header/footer for emails.',
+		'woocommerce-gutenberg-emails'
+	),
+	supports: {
+		multiple: false,
+	},
+	attributes: {
+		footer: {
+			type: 'string',
+			source: 'html',
+			default: '{footer}',
+			selector: '#credit',
+		},
+		headerImage: {
+			type: 'string',
+			source: 'html',
+			default: '{header_image}',
+			selector: '#template_header_image',
+		},
+		heading: {
+			type: 'string',
+			source: 'html',
+			default: '{heading}',
+			selector: 'h1',
+		},
+	},
+
+	/**
+	 * Renders and manages the block.
+	 *
+	 * @return {Object} Editor component.
+	 */
+	edit( { attributes, setAttributes } ) {
+		const { footer, headerImage, heading } = attributes;
+		return renderTemplate( {
+			image: (
+				<RichText
+					identifier="header_image"
+					value={ headerImage }
+					onChange={
+						( nextValue ) => setAttributes( {
+							headerImage: nextValue,
+						} )
+					}
+					placeholder={ __( 'Add your header image…', 'woocommerce-gutenberg-emails' ) }
+				/>
+			),
+			header: (
+				<RichText
+					tagName="h1"
+					identifier="heading"
+					value={ heading }
+					onChange={
+						( nextValue ) => setAttributes( {
+							heading: nextValue,
+						} )
+					}
+					placeholder={ __( 'Write a heading…', 'woocommerce-gutenberg-emails' ) }
+				/>
+			),
+			content: <InnerBlocks />,
+			footer: (
+				<RichText
+					identifier="footer"
+					value={ footer }
+					onChange={
+						( nextValue ) => setAttributes( {
+							footer: nextValue,
+						} )
+					}
+					placeholder={ __( 'Write a footer…', 'woocommerce-gutenberg-emails' ) }
+				/>
+			),
+		} );
+	},
+
+	/**
+	 * Block content is rendered in PHP, not via save function.
+	 *
+	 * @return {Object} Visible component.
+	 */
+	save( { attributes } ) {
+		const { footer, headerImage, heading } = attributes;
+		return renderTemplate( {
+			image: <RichText.Content value={ headerImage } />,
+			header: <RichText.Content tagName="h1" value={ heading } />,
+			content: <InnerBlocks.Content />,
+			footer: <RichText.Content value={ footer } />,
+		} );
+	},
+} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
 	...defaultConfig,
 	entry: {
 		'order-details': './src/blocks/order-details/index.js',
+		'email-wrapper': './src/blocks/email-wrapper/index.js',
 	},
 	module: {
 		...defaultConfig.module,


### PR DESCRIPTION
Fixes #9.

![email-2](https://user-images.githubusercontent.com/3616980/56815183-f8084d00-6840-11e9-9caf-90fdf018a968.gif)

**Test**
- Edit an email.
- Add an _Email Wrapper_ block.
- Verify you can edit the header image, the heading and the footer sections.
- Verify you can add any block you want in the content section.
- Make sure you can't add any other _Email Wrapper_ block in the same email.
- Send an email and verify the header and footer are there and the placeholders are replaced.

**Follow-ups/Questions**
- Currently the placeholders are plain text in the `RichText` fields, but it would be great to use the placeholders blocks from #27 once they can be added inline.
- Currently, if you edit the footer or the header image in one email, it's only edited in that single email. Maybe users will expect editing the header/footer to be propagated in all other templates?
- It's possible to add more blocks before and after the _Email Wrapper_ but we would like it to be the only "parent block" of the email.